### PR TITLE
Protect against logical comparison errors in wifi_connect.c

### DIFF
--- a/_13_Internet_Connection/v5/wifi-AP_4/components/wifi_connect/wifi_connect.c
+++ b/_13_Internet_Connection/v5/wifi-AP_4/components/wifi_connect/wifi_connect.c
@@ -97,7 +97,7 @@ esp_err_t wifi_connect_sta(char *ssid, char *pass, int timeout)
     ESP_ERROR_CHECK(esp_wifi_start());
 
     EventBits_t result = xEventGroupWaitBits(wifi_events, CONNECTED | DISCONNECTED, true, false, pdMS_TO_TICKS(timeout));
-    if (result == CONNECTED)
+    if ((result & CONNECTED) == CONNECTED)
         return ESP_OK;
     return ESP_FAIL;
 }

--- a/_13_Internet_Connection/v5/wifi-disconnection/components/wifi_connect/wifi_connect.c
+++ b/_13_Internet_Connection/v5/wifi-disconnection/components/wifi_connect/wifi_connect.c
@@ -102,7 +102,7 @@ esp_err_t wifi_connect_sta(char *ssid, char *pass, int timeout)
     ESP_ERROR_CHECK(esp_wifi_start());
 
     EventBits_t result = xEventGroupWaitBits(wifi_events, CONNECTED | DISCONNECTED, true, false, pdMS_TO_TICKS(timeout));
-    if (result == CONNECTED)
+    if ((result & CONNECTED) == CONNECTED)
         return ESP_OK;
     return ESP_FAIL;
 }

--- a/_13_Internet_Connection/v5/wifi-err_3/components/wifi_connect/wifi_connect.c
+++ b/_13_Internet_Connection/v5/wifi-err_3/components/wifi_connect/wifi_connect.c
@@ -97,7 +97,7 @@ esp_err_t wifi_connect_sta(char *ssid, char *pass, int timeout)
     ESP_ERROR_CHECK(esp_wifi_start());
 
     EventBits_t result = xEventGroupWaitBits(wifi_events, CONNECTED | DISCONNECTED, true, false, pdMS_TO_TICKS(timeout));
-    if (result == CONNECTED)
+    if ((result & CONNECTED) == CONNECTED)
         return ESP_OK;
     return ESP_FAIL;
 }

--- a/_13_Internet_Connection/v5/wifi-sta_2/components/wifi_connect/wifi_connect.c
+++ b/_13_Internet_Connection/v5/wifi-sta_2/components/wifi_connect/wifi_connect.c
@@ -71,7 +71,7 @@ esp_err_t wifi_connect_sta(char *ssid, char *pass, int timeout)
     ESP_ERROR_CHECK(esp_wifi_start());
 
     EventBits_t result = xEventGroupWaitBits(wifi_events, CONNECTED | DISCONNECTED, true, false, pdMS_TO_TICKS(timeout));
-    if (result == CONNECTED)
+    if ((result & CONNECTED) == CONNECTED)
         return ESP_OK;
     return ESP_FAIL;
 }


### PR DESCRIPTION
If any additional bits are being used in `wifi_connect` (eg. by setting both a `CONNECTED` and `IP_ASSIGNED` flag), a direct comparison of `result == CONNECTED` will fail even if the `CONNECTED` bit is set, due to the presence of other bits.

Since the checked flags are cleared via `xClearOnExit = pdTRUE`, the flag notifying an IP assignment will be lost, and not set again in any reasonable amount of time. This is a simple change to evaluate the bitwise `&` result of the return to evaluate if the correct flag has been set.